### PR TITLE
fix: dependabot now looks at the correct directory when checking for updates regarding GitHub-Actions in JexxaBlankArchetype

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "github-actions"
-    directory: "/jexxa-blank-archetype/src/main/resources/archetype-resources/.github"
+    directory: "/jexxa-blank-archetype/src/main/resources/archetype-resources/.github/workflows"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"


### PR DESCRIPTION
The Action-Scripts are located in the .github/workflows directory, not in the .github directory. This is already implemented correctly for the JLegMedBlankArchetype.